### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/pyspider/database/__init__.py
+++ b/pyspider/database/__init__.py
@@ -51,7 +51,7 @@ def _connect_database(url):  # NOQA
 
     scheme = parsed.scheme.split('+')
     if len(scheme) == 1:
-        raise Exception('wrong scheme format: %s' % parsed.scheme)
+        raise Exception('wrong scheme format: {0!s}'.format(parsed.scheme))
     else:
         engine, dbtype = scheme[0], scheme[-1]
         other_scheme = "+".join(scheme[1:-1])
@@ -92,7 +92,7 @@ def _connect_database(url):  # NOQA
         elif not parsed.path:
             path = ':memory:'
         else:
-            raise Exception('error path: %s' % parsed.path)
+            raise Exception('error path: {0!s}'.format(parsed.path))
 
         if dbtype == 'taskdb':
             from .sqlite.taskdb import TaskDB
@@ -124,7 +124,7 @@ def _connect_database(url):  # NOQA
             raise LookupError
     elif engine == 'sqlalchemy':
         if not other_scheme:
-            raise Exception('wrong scheme format: %s' % parsed.scheme)
+            raise Exception('wrong scheme format: {0!s}'.format(parsed.scheme))
         url = url.replace(parsed.scheme, other_scheme)
 
         if dbtype == 'taskdb':
@@ -169,4 +169,4 @@ def _connect_database(url):  # NOQA
             from .elasticsearch.taskdb import TaskDB
             return TaskDB([parsed.netloc], index=index)
     else:
-        raise Exception('unknown engine: %s' % engine)
+        raise Exception('unknown engine: {0!s}'.format(engine))

--- a/pyspider/database/basedb.py
+++ b/pyspider/database/basedb.py
@@ -25,7 +25,7 @@ class BaseDB:
 
     @staticmethod
     def escape(string):
-        return '`%s`' % string
+        return '`{0!s}`'.format(string)
 
     @property
     def dbcur(self):
@@ -41,11 +41,11 @@ class BaseDB:
         if isinstance(what, list) or isinstance(what, tuple) or what is None:
             what = ','.join(self.escape(f) for f in what) if what else '*'
 
-        sql_query = "SELECT %s FROM %s" % (what, tablename)
+        sql_query = "SELECT {0!s} FROM {1!s}".format(what, tablename)
         if where:
-            sql_query += " WHERE %s" % where
+            sql_query += " WHERE {0!s}".format(where)
         if limit:
-            sql_query += " LIMIT %d, %d" % (offset, limit)
+            sql_query += " LIMIT {0:d}, {1:d}".format(offset, limit)
         logger.debug("<sql: %s>", sql_query)
 
         for row in self._execute(sql_query, where_values):
@@ -57,13 +57,13 @@ class BaseDB:
         if isinstance(what, list) or isinstance(what, tuple) or what is None:
             what = ','.join(self.escape(f) for f in what) if what else '*'
 
-        sql_query = "SELECT %s FROM %s" % (what, tablename)
+        sql_query = "SELECT {0!s} FROM {1!s}".format(what, tablename)
         if where:
-            sql_query += " WHERE %s" % where
+            sql_query += " WHERE {0!s}".format(where)
         if order:
-            sql_query += ' ORDER BY %s' % order
+            sql_query += ' ORDER BY {0!s}'.format(order)
         if limit:
-            sql_query += " LIMIT %d, %d" % (offset, limit)
+            sql_query += " LIMIT {0:d}, {1:d}".format(offset, limit)
         logger.debug("<sql: %s>", sql_query)
 
         dbcur = self._execute(sql_query, where_values)
@@ -77,9 +77,9 @@ class BaseDB:
         if values:
             _keys = ", ".join(self.escape(k) for k in values)
             _values = ", ".join([self.placeholder, ] * len(values))
-            sql_query = "REPLACE INTO %s (%s) VALUES (%s)" % (tablename, _keys, _values)
+            sql_query = "REPLACE INTO {0!s} ({1!s}) VALUES ({2!s})".format(tablename, _keys, _values)
         else:
-            sql_query = "REPLACE INTO %s DEFAULT VALUES" % tablename
+            sql_query = "REPLACE INTO {0!s} DEFAULT VALUES".format(tablename)
         logger.debug("<sql: %s>", sql_query)
 
         if values:
@@ -93,9 +93,9 @@ class BaseDB:
         if values:
             _keys = ", ".join((self.escape(k) for k in values))
             _values = ", ".join([self.placeholder, ] * len(values))
-            sql_query = "INSERT INTO %s (%s) VALUES (%s)" % (tablename, _keys, _values)
+            sql_query = "INSERT INTO {0!s} ({1!s}) VALUES ({2!s})".format(tablename, _keys, _values)
         else:
-            sql_query = "INSERT INTO %s DEFAULT VALUES" % tablename
+            sql_query = "INSERT INTO {0!s} DEFAULT VALUES".format(tablename)
         logger.debug("<sql: %s>", sql_query)
 
         if values:
@@ -107,18 +107,18 @@ class BaseDB:
     def _update(self, tablename=None, where="1=0", where_values=[], **values):
         tablename = self.escape(tablename or self.__tablename__)
         _key_values = ", ".join([
-            "%s = %s" % (self.escape(k), self.placeholder) for k in values
+            "{0!s} = {1!s}".format(self.escape(k), self.placeholder) for k in values
         ])
-        sql_query = "UPDATE %s SET %s WHERE %s" % (tablename, _key_values, where)
+        sql_query = "UPDATE {0!s} SET {1!s} WHERE {2!s}".format(tablename, _key_values, where)
         logger.debug("<sql: %s>", sql_query)
 
         return self._execute(sql_query, list(itervalues(values)) + list(where_values))
 
     def _delete(self, tablename=None, where="1=0", where_values=[]):
         tablename = self.escape(tablename or self.__tablename__)
-        sql_query = "DELETE FROM %s" % tablename
+        sql_query = "DELETE FROM {0!s}".format(tablename)
         if where:
-            sql_query += " WHERE %s" % where
+            sql_query += " WHERE {0!s}".format(where)
         logger.debug("<sql: %s>", sql_query)
 
         return self._execute(sql_query, where_values)
@@ -133,8 +133,7 @@ if __name__ == "__main__":
             self.conn = sqlite3.connect(":memory:")
             cursor = self.conn.cursor()
             cursor.execute(
-                '''CREATE TABLE `%s` (id INTEGER PRIMARY KEY AUTOINCREMENT, name, age)'''
-                % self.__tablename__
+                '''CREATE TABLE `{0!s}` (id INTEGER PRIMARY KEY AUTOINCREMENT, name, age)'''.format(self.__tablename__)
             )
 
         @property

--- a/pyspider/database/elasticsearch/resultdb.py
+++ b/pyspider/database/elasticsearch/resultdb.py
@@ -48,7 +48,7 @@ class ResultDB(BaseResultDB):
             'updatetime': time.time(),
         }
         return self.es.index(index=self.index, doc_type=self.__type__,
-                             body=obj, id='%s:%s' % (project, taskid))
+                             body=obj, id='{0!s}:{1!s}'.format(project, taskid))
 
     def select(self, project, fields=None, offset=0, limit=0):
         if not limit:
@@ -71,7 +71,7 @@ class ResultDB(BaseResultDB):
                              ).get('count', 0)
 
     def get(self, project, taskid, fields=None):
-        ret = self.es.get(index=self.index, doc_type=self.__type__, id="%s:%s" % (project, taskid),
+        ret = self.es.get(index=self.index, doc_type=self.__type__, id="{0!s}:{1!s}".format(project, taskid),
                           _source_include=fields or [], ignore=404)
         return ret.get('_source', None)
 

--- a/pyspider/database/elasticsearch/taskdb.py
+++ b/pyspider/database/elasticsearch/taskdb.py
@@ -75,7 +75,7 @@ class TaskDB(BaseTaskDB):
     def get_task(self, project, taskid, fields=None):
         if self._changed:
             self.refresh()
-        ret = self.es.get(index=self.index, doc_type=self.__type__, id="%s:%s" % (project, taskid),
+        ret = self.es.get(index=self.index, doc_type=self.__type__, id="{0!s}:{1!s}".format(project, taskid),
                           _source_include=fields or [], ignore=404)
         return self._parse(ret.get('_source', None))
 
@@ -98,14 +98,14 @@ class TaskDB(BaseTaskDB):
         obj['project'] = project
         obj['updatetime'] = time.time()
         return self.es.index(index=self.index, doc_type=self.__type__,
-                             body=self._stringify(obj), id='%s:%s' % (project, taskid))
+                             body=self._stringify(obj), id='{0!s}:{1!s}'.format(project, taskid))
 
     def update(self, project, taskid, obj={}, **kwargs):
         self._changed = True
         obj = dict(obj)
         obj.update(kwargs)
         obj['updatetime'] = time.time()
-        return self.es.update(index=self.index, doc_type=self.__type__, id='%s:%s' % (project, taskid),
+        return self.es.update(index=self.index, doc_type=self.__type__, id='{0!s}:{1!s}'.format(project, taskid),
                               body={"doc": self._stringify(obj)}, ignore=404)
 
     def drop(self, project):

--- a/pyspider/database/mongodb/mongodbbase.py
+++ b/pyspider/database/mongodb/mongodbbase.py
@@ -13,7 +13,7 @@ class SplitTableMixin(object):
 
     def _collection_name(self, project):
         if self.collection_prefix:
-            return "%s.%s" % (self.collection_prefix, project)
+            return "{0!s}.{1!s}".format(self.collection_prefix, project)
         else:
             return project
 
@@ -32,7 +32,7 @@ class SplitTableMixin(object):
         self._last_update_projects = time.time()
         self.projects = set()
         if self.collection_prefix:
-            prefix = "%s." % self.collection_prefix
+            prefix = "{0!s}.".format(self.collection_prefix)
         else:
             prefix = ''
         for each in self.database.collection_names():

--- a/pyspider/database/mysql/mysqlbase.py
+++ b/pyspider/database/mysql/mysqlbase.py
@@ -28,7 +28,7 @@ class SplitTableMixin(object):
 
     def _tablename(self, project):
         if self.__tablename__:
-            return '%s_%s' % (self.__tablename__, project)
+            return '{0!s}_{1!s}'.format(self.__tablename__, project)
         else:
             return project
 
@@ -47,7 +47,7 @@ class SplitTableMixin(object):
         self._last_update_projects = time.time()
         self.projects = set()
         if self.__tablename__:
-            prefix = '%s_' % self.__tablename__
+            prefix = '{0!s}_'.format(self.__tablename__)
         else:
             prefix = ''
         for project, in self._execute('show tables;'):
@@ -61,5 +61,5 @@ class SplitTableMixin(object):
         if project not in self.projects:
             return
         tablename = self._tablename(project)
-        self._execute("DROP TABLE %s" % self.escape(tablename))
+        self._execute("DROP TABLE {0!s}".format(self.escape(tablename)))
         self._list_project()

--- a/pyspider/database/mysql/projectdb.py
+++ b/pyspider/database/mysql/projectdb.py
@@ -22,10 +22,10 @@ class ProjectDB(MySQLMixin, BaseProjectDB, BaseDB):
         self.conn = mysql.connector.connect(user=user, password=passwd,
                                             host=host, port=port, autocommit=True)
         if database not in [x[0] for x in self._execute('show databases')]:
-            self._execute('CREATE DATABASE %s' % self.escape(database))
+            self._execute('CREATE DATABASE {0!s}'.format(self.escape(database)))
         self.conn.database = database
 
-        self._execute('''CREATE TABLE IF NOT EXISTS %s (
+        self._execute('''CREATE TABLE IF NOT EXISTS {0!s} (
             `name` varchar(64) PRIMARY KEY,
             `group` varchar(64),
             `status` varchar(16),
@@ -34,7 +34,7 @@ class ProjectDB(MySQLMixin, BaseProjectDB, BaseDB):
             `rate` float(11, 4),
             `burst` float(11, 4),
             `updatetime` double(16, 4)
-            ) ENGINE=InnoDB CHARSET=utf8''' % self.escape(self.__tablename__))
+            ) ENGINE=InnoDB CHARSET=utf8'''.format(self.escape(self.__tablename__)))
 
     def insert(self, name, obj={}):
         obj = dict(obj)
@@ -46,22 +46,22 @@ class ProjectDB(MySQLMixin, BaseProjectDB, BaseDB):
         obj = dict(obj)
         obj.update(kwargs)
         obj['updatetime'] = time.time()
-        ret = self._update(where="`name` = %s" % self.placeholder, where_values=(name, ), **obj)
+        ret = self._update(where="`name` = {0!s}".format(self.placeholder), where_values=(name, ), **obj)
         return ret.rowcount
 
     def get_all(self, fields=None):
         return self._select2dic(what=fields)
 
     def get(self, name, fields=None):
-        where = "`name` = %s" % self.placeholder
+        where = "`name` = {0!s}".format(self.placeholder)
         for each in self._select2dic(what=fields, where=where, where_values=(name, )):
             return each
         return None
 
     def drop(self, name):
-        where = "`name` = %s" % self.placeholder
+        where = "`name` = {0!s}".format(self.placeholder)
         return self._delete(where=where, where_values=(name, ))
 
     def check_update(self, timestamp, fields=None):
-        where = "`updatetime` >= %f" % timestamp
+        where = "`updatetime` >= {0:f}".format(timestamp)
         return self._select2dic(what=fields, where=where)

--- a/pyspider/database/mysql/resultdb.py
+++ b/pyspider/database/mysql/resultdb.py
@@ -26,7 +26,7 @@ class ResultDB(MySQLMixin, SplitTableMixin, BaseResultDB, BaseDB):
         self.conn = mysql.connector.connect(user=user, password=passwd,
                                             host=host, port=port, autocommit=True)
         if database not in [x[0] for x in self._execute('show databases')]:
-            self._execute('CREATE DATABASE %s' % self.escape(database))
+            self._execute('CREATE DATABASE {0!s}'.format(self.escape(database)))
         self.conn.database = database
         self._list_project()
 
@@ -35,12 +35,12 @@ class ResultDB(MySQLMixin, SplitTableMixin, BaseResultDB, BaseDB):
         tablename = self._tablename(project)
         if tablename in [x[0] for x in self._execute('show tables')]:
             return
-        self._execute('''CREATE TABLE %s (
+        self._execute('''CREATE TABLE {0!s} (
             `taskid` varchar(64) PRIMARY KEY,
             `url` varchar(1024),
             `result` MEDIUMBLOB,
             `updatetime` double(16, 4)
-            ) ENGINE=InnoDB CHARSET=utf8''' % self.escape(tablename))
+            ) ENGINE=InnoDB CHARSET=utf8'''.format(self.escape(tablename)))
 
     def _parse(self, data):
         for key, value in list(six.iteritems(data)):
@@ -85,7 +85,7 @@ class ResultDB(MySQLMixin, SplitTableMixin, BaseResultDB, BaseDB):
         if project not in self.projects:
             return 0
         tablename = self._tablename(project)
-        for count, in self._execute("SELECT count(1) FROM %s" % self.escape(tablename)):
+        for count, in self._execute("SELECT count(1) FROM {0!s}".format(self.escape(tablename))):
             return count
 
     def get(self, project, taskid, fields=None):
@@ -94,7 +94,7 @@ class ResultDB(MySQLMixin, SplitTableMixin, BaseResultDB, BaseDB):
         if project not in self.projects:
             return
         tablename = self._tablename(project)
-        where = "`taskid` = %s" % self.placeholder
+        where = "`taskid` = {0!s}".format(self.placeholder)
         for task in self._select2dic(tablename, what=fields,
                                      where=where, where_values=(taskid, )):
             return self._parse(task)

--- a/pyspider/database/mysql/taskdb.py
+++ b/pyspider/database/mysql/taskdb.py
@@ -27,7 +27,7 @@ class TaskDB(MySQLMixin, SplitTableMixin, BaseTaskDB, BaseDB):
         self.conn = mysql.connector.connect(user=user, password=passwd,
                                             host=host, port=port, autocommit=True)
         if database not in [x[0] for x in self._execute('show databases')]:
-            self._execute('CREATE DATABASE %s' % self.escape(database))
+            self._execute('CREATE DATABASE {0!s}'.format(self.escape(database)))
         self.conn.database = database
         self._list_project()
 
@@ -36,7 +36,7 @@ class TaskDB(MySQLMixin, SplitTableMixin, BaseTaskDB, BaseDB):
         tablename = self._tablename(project)
         if tablename in [x[0] for x in self._execute('show tables')]:
             return
-        self._execute('''CREATE TABLE IF NOT EXISTS %s (
+        self._execute('''CREATE TABLE IF NOT EXISTS {0!s} (
             `taskid` varchar(64) PRIMARY KEY,
             `project` varchar(64),
             `url` varchar(1024),
@@ -48,7 +48,7 @@ class TaskDB(MySQLMixin, SplitTableMixin, BaseTaskDB, BaseDB):
             `lastcrawltime` double(16, 4),
             `updatetime` double(16, 4),
             INDEX `status_index` (`status`)
-            ) ENGINE=InnoDB CHARSET=utf8''' % self.escape(tablename))
+            ) ENGINE=InnoDB CHARSET=utf8'''.format(self.escape(tablename)))
 
     def _parse(self, data):
         for key, value in list(six.iteritems(data)):
@@ -71,7 +71,7 @@ class TaskDB(MySQLMixin, SplitTableMixin, BaseTaskDB, BaseDB):
     def load_tasks(self, status, project=None, fields=None):
         if project and project not in self.projects:
             return
-        where = "`status` = %s" % self.placeholder
+        where = "`status` = {0!s}".format(self.placeholder)
 
         if project:
             projects = [project, ]
@@ -90,7 +90,7 @@ class TaskDB(MySQLMixin, SplitTableMixin, BaseTaskDB, BaseDB):
             self._list_project()
         if project not in self.projects:
             return None
-        where = "`taskid` = %s" % self.placeholder
+        where = "`taskid` = {0!s}".format(self.placeholder)
         tablename = self._tablename(project)
         for each in self._select2dic(tablename, what=fields, where=where, where_values=(taskid, )):
             return self._parse(each)
@@ -103,8 +103,8 @@ class TaskDB(MySQLMixin, SplitTableMixin, BaseTaskDB, BaseDB):
         if project not in self.projects:
             return result
         tablename = self._tablename(project)
-        for status, count in self._execute("SELECT `status`, count(1) FROM %s GROUP BY `status`" %
-                                           self.escape(tablename)):
+        for status, count in self._execute("SELECT `status`, count(1) FROM {0!s} GROUP BY `status`".format(
+                                           self.escape(tablename))):
             result[status] = count
         return result
 
@@ -132,7 +132,7 @@ class TaskDB(MySQLMixin, SplitTableMixin, BaseTaskDB, BaseDB):
         obj['updatetime'] = time.time()
         return self._update(
             tablename,
-            where="`taskid` = %s" % self.placeholder,
+            where="`taskid` = {0!s}".format(self.placeholder),
             where_values=(taskid, ),
             **self._stringify(obj)
         )

--- a/pyspider/database/redis/taskdb.py
+++ b/pyspider/database/redis/taskdb.py
@@ -30,10 +30,10 @@ class TaskDB(BaseTaskDB):
             self.scan_available = False
 
     def _gen_key(self, project, taskid):
-        return "%s%s_%s" % (self.__prefix__, project, taskid)
+        return "{0!s}{1!s}_{2!s}".format(self.__prefix__, project, taskid)
 
     def _gen_status_key(self, project, status):
-        return '%s%s_status_%d' % (self.__prefix__, project, status)
+        return '{0!s}{1!s}_status_{2:d}'.format(self.__prefix__, project, status)
 
     def _parse(self, data):
         if six.PY3:
@@ -169,7 +169,7 @@ class TaskDB(BaseTaskDB):
         else:
             scan_method = self.redis.keys
 
-        for each in itertools.tee(scan_method("%s%s_*" % (self.__prefix__, project)), 100):
+        for each in itertools.tee(scan_method("{0!s}{1!s}_*".format(self.__prefix__, project)), 100):
             each = list(each)
             if each:
                 self.redis.delete(*each)

--- a/pyspider/database/sqlalchemy/projectdb.py
+++ b/pyspider/database/sqlalchemy/projectdb.py
@@ -41,7 +41,7 @@ class ProjectDB(BaseProjectDB):
                 engine = create_engine(self.url)
                 conn = engine.connect()
                 conn.execute("commit")
-                conn.execute("CREATE DATABASE %s" % database)
+                conn.execute("CREATE DATABASE {0!s}".format(database))
             except sqlalchemy.exc.SQLAlchemyError:
                 pass
             self.url.database = database

--- a/pyspider/database/sqlalchemy/resultdb.py
+++ b/pyspider/database/sqlalchemy/resultdb.py
@@ -38,7 +38,7 @@ class ResultDB(SplitTableMixin, BaseResultDB):
             self.url.database = None
             try:
                 engine = create_engine(self.url, convert_unicode=True)
-                engine.execute("CREATE DATABASE IF NOT EXISTS %s" % database)
+                engine.execute("CREATE DATABASE IF NOT EXISTS {0!s}".format(database))
             except sqlalchemy.exc.SQLAlchemyError:
                 pass
             self.url.database = database

--- a/pyspider/database/sqlalchemy/sqlalchemybase.py
+++ b/pyspider/database/sqlalchemy/sqlalchemybase.py
@@ -20,7 +20,7 @@ class SplitTableMixin(object):
 
     def _tablename(self, project):
         if self.__tablename__:
-            return '%s_%s' % (self.__tablename__, project)
+            return '{0!s}_{1!s}'.format(self.__tablename__, project)
         else:
             return project
 
@@ -39,7 +39,7 @@ class SplitTableMixin(object):
         self._last_update_projects = time.time()
         self.projects = set()
         if self.__tablename__:
-            prefix = '%s_' % self.__tablename__
+            prefix = '{0!s}_'.format(self.__tablename__)
         else:
             prefix = ''
 

--- a/pyspider/database/sqlalchemy/taskdb.py
+++ b/pyspider/database/sqlalchemy/taskdb.py
@@ -46,7 +46,7 @@ class TaskDB(SplitTableMixin, BaseTaskDB):
                 engine = create_engine(self.url)
                 conn = engine.connect()
                 conn.execute("commit")
-                conn.execute("CREATE DATABASE %s" % database)
+                conn.execute("CREATE DATABASE {0!s}".format(database))
             except sqlalchemy.exc.SQLAlchemyError:
                 pass
             self.url.database = database
@@ -59,7 +59,7 @@ class TaskDB(SplitTableMixin, BaseTaskDB):
         if project in self.projects:
             return
         self.table.name = self._tablename(project)
-        Index('status_%s_index' % self.table.name, self.table.c.status)
+        Index('status_{0!s}_index'.format(self.table.name), self.table.c.status)
         self.table.create(self.engine, checkfirst=True)
         self.table.indexes.clear()
 

--- a/pyspider/database/sqlite/projectdb.py
+++ b/pyspider/database/sqlite/projectdb.py
@@ -20,12 +20,12 @@ class ProjectDB(SQLiteMixin, BaseProjectDB, BaseDB):
         self.path = path
         self.last_pid = 0
         self.conn = None
-        self._execute('''CREATE TABLE IF NOT EXISTS `%s` (
+        self._execute('''CREATE TABLE IF NOT EXISTS `{0!s}` (
                 name PRIMARY KEY,
                 `group`,
                 status, script, comments,
                 rate, burst, updatetime
-                )''' % self.__tablename__)
+                )'''.format(self.__tablename__))
 
     def insert(self, name, obj={}):
         obj = dict(obj)
@@ -37,22 +37,22 @@ class ProjectDB(SQLiteMixin, BaseProjectDB, BaseDB):
         obj = dict(obj)
         obj.update(kwargs)
         obj['updatetime'] = time.time()
-        ret = self._update(where="`name` = %s" % self.placeholder, where_values=(name, ), **obj)
+        ret = self._update(where="`name` = {0!s}".format(self.placeholder), where_values=(name, ), **obj)
         return ret.rowcount
 
     def get_all(self, fields=None):
         return self._select2dic(what=fields)
 
     def get(self, name, fields=None):
-        where = "`name` = %s" % self.placeholder
+        where = "`name` = {0!s}".format(self.placeholder)
         for each in self._select2dic(what=fields, where=where, where_values=(name, )):
             return each
         return None
 
     def check_update(self, timestamp, fields=None):
-        where = "`updatetime` >= %f" % timestamp
+        where = "`updatetime` >= {0:f}".format(timestamp)
         return self._select2dic(what=fields, where=where)
 
     def drop(self, name):
-        where = "`name` = %s" % self.placeholder
+        where = "`name` = {0!s}".format(self.placeholder)
         return self._delete(where=where, where_values=(name, ))

--- a/pyspider/database/sqlite/resultdb.py
+++ b/pyspider/database/sqlite/resultdb.py
@@ -27,12 +27,12 @@ class ResultDB(SQLiteMixin, SplitTableMixin, BaseResultDB, BaseDB):
     def _create_project(self, project):
         assert re.match(r'^\w+$', project) is not None
         tablename = self._tablename(project)
-        self._execute('''CREATE TABLE IF NOT EXISTS `%s` (
+        self._execute('''CREATE TABLE IF NOT EXISTS `{0!s}` (
                 taskid PRIMARY KEY,
                 url,
                 result,
                 updatetime
-                )''' % tablename)
+                )'''.format(tablename))
 
     def _parse(self, data):
         if 'result' in data:
@@ -74,7 +74,7 @@ class ResultDB(SQLiteMixin, SplitTableMixin, BaseResultDB, BaseDB):
         if project not in self.projects:
             return 0
         tablename = self._tablename(project)
-        for count, in self._execute("SELECT count(1) FROM %s" % self.escape(tablename)):
+        for count, in self._execute("SELECT count(1) FROM {0!s}".format(self.escape(tablename))):
             return count
 
     def get(self, project, taskid, fields=None):
@@ -83,7 +83,7 @@ class ResultDB(SQLiteMixin, SplitTableMixin, BaseResultDB, BaseDB):
         if project not in self.projects:
             return
         tablename = self._tablename(project)
-        where = "`taskid` = %s" % self.placeholder
+        where = "`taskid` = {0!s}".format(self.placeholder)
         for task in self._select2dic(tablename, what=fields,
                                      where=where, where_values=(taskid, )):
             return self._parse(task)

--- a/pyspider/database/sqlite/sqlitebase.py
+++ b/pyspider/database/sqlite/sqlitebase.py
@@ -27,7 +27,7 @@ class SplitTableMixin(object):
 
     def _tablename(self, project):
         if self.__tablename__:
-            return '%s_%s' % (self.__tablename__, project)
+            return '{0!s}_{1!s}'.format(self.__tablename__, project)
         else:
             return project
 
@@ -46,7 +46,7 @@ class SplitTableMixin(object):
         self._last_update_projects = time.time()
         self.projects = set()
         if self.__tablename__:
-            prefix = '%s_' % self.__tablename__
+            prefix = '{0!s}_'.format(self.__tablename__)
         else:
             prefix = ''
         for project, in self._select('sqlite_master', what='name',
@@ -61,5 +61,5 @@ class SplitTableMixin(object):
         if project not in self.projects:
             return
         tablename = self._tablename(project)
-        self._execute("DROP TABLE %s" % self.escape(tablename))
+        self._execute("DROP TABLE {0!s}".format(self.escape(tablename)))
         self._list_project()

--- a/pyspider/database/sqlite/taskdb.py
+++ b/pyspider/database/sqlite/taskdb.py
@@ -27,16 +27,15 @@ class TaskDB(SQLiteMixin, SplitTableMixin, BaseTaskDB, BaseDB):
     def _create_project(self, project):
         assert re.match(r'^\w+$', project) is not None
         tablename = self._tablename(project)
-        self._execute('''CREATE TABLE IF NOT EXISTS `%s` (
+        self._execute('''CREATE TABLE IF NOT EXISTS `{0!s}` (
                 taskid PRIMARY KEY,
                 project,
                 url, status,
                 schedule, fetch, process, track,
                 lastcrawltime, updatetime
-                )''' % tablename)
+                )'''.format(tablename))
         self._execute(
-            '''CREATE INDEX `status_%s_index` ON %s (status)'''
-            % (tablename, self.escape(tablename))
+            '''CREATE INDEX `status_{0!s}_index` ON {1!s} (status)'''.format(tablename, self.escape(tablename))
         )
 
     def _parse(self, data):
@@ -57,7 +56,7 @@ class TaskDB(SQLiteMixin, SplitTableMixin, BaseTaskDB, BaseDB):
     def load_tasks(self, status, project=None, fields=None):
         if project and project not in self.projects:
             return
-        where = "status = %d" % status
+        where = "status = {0:d}".format(status)
 
         if project:
             projects = [project, ]
@@ -74,7 +73,7 @@ class TaskDB(SQLiteMixin, SplitTableMixin, BaseTaskDB, BaseDB):
             self._list_project()
         if project not in self.projects:
             return None
-        where = "`taskid` = %s" % self.placeholder
+        where = "`taskid` = {0!s}".format(self.placeholder)
         if project not in self.projects:
             return None
         tablename = self._tablename(project)
@@ -92,8 +91,8 @@ class TaskDB(SQLiteMixin, SplitTableMixin, BaseTaskDB, BaseDB):
         if project not in self.projects:
             return result
         tablename = self._tablename(project)
-        for status, count in self._execute("SELECT `status`, count(1) FROM %s GROUP BY `status`" %
-                                           self.escape(tablename)):
+        for status, count in self._execute("SELECT `status`, count(1) FROM {0!s} GROUP BY `status`".format(
+                                           self.escape(tablename))):
             result[status] = count
         return result
 
@@ -116,6 +115,6 @@ class TaskDB(SQLiteMixin, SplitTableMixin, BaseTaskDB, BaseDB):
         obj.update(kwargs)
         obj['updatetime'] = time.time()
         return self._update(
-            tablename, where="`taskid` = %s" % self.placeholder, where_values=(taskid, ),
+            tablename, where="`taskid` = {0!s}".format(self.placeholder), where_values=(taskid, ),
             **self._stringify(obj)
         )

--- a/pyspider/fetcher/tornado_fetcher.py
+++ b/pyspider/fetcher/tornado_fetcher.py
@@ -61,7 +61,7 @@ fetcher_output = {
 
 
 class Fetcher(object):
-    user_agent = "pyspider/%s (+http://pyspider.org/)" % pyspider.__version__
+    user_agent = "pyspider/{0!s} (+http://pyspider.org/)".format(pyspider.__version__)
     default_options = {
         'method': 'GET',
         'headers': {
@@ -377,7 +377,7 @@ class Fetcher(object):
                     and task_fetch.get('allow_redirects', True)):
                 if max_redirects <= 0:
                     error = tornado.httpclient.HTTPError(
-                        599, 'Maximum (%d) redirects followed' % task_fetch.get('max_redirects', 5),
+                        599, 'Maximum ({0:d}) redirects followed'.format(task_fetch.get('max_redirects', 5)),
                         response)
                     raise gen.Return(handle_error(error))
                 if response.code in (302, 303):
@@ -469,7 +469,7 @@ class Fetcher(object):
         fetch['headers'] = dict(fetch['headers'])
         try:
             request = tornado.httpclient.HTTPRequest(
-                url="%s" % self.phantomjs_proxy, method="POST",
+                url="{0!s}".format(self.phantomjs_proxy), method="POST",
                 body=json.dumps(fetch), **request_conf)
         except Exception as e:
             raise gen.Return(handle_error(e))

--- a/pyspider/libs/base_handler.py
+++ b/pyspider/libs/base_handler.py
@@ -157,7 +157,7 @@ class BaseHandler(object):
         process = task.get('process', {})
         callback = process.get('callback', '__call__')
         if not hasattr(self, callback):
-            raise NotImplementedError("self.%s() not implemented!" % callback)
+            raise NotImplementedError("self.{0!s}() not implemented!".format(callback))
 
         function = getattr(self, callback)
         # do not run_func when 304
@@ -227,7 +227,7 @@ class BaseHandler(object):
                 func = callback
                 kwargs['callback'] = func.__name__
             else:
-                raise NotImplementedError("self.%s() not implemented!" % callback)
+                raise NotImplementedError("self.{0!s}() not implemented!".format(callback))
             if hasattr(func, '_config'):
                 for k, v in iteritems(func._config):
                     if isinstance(v, dict) and isinstance(kwargs.get(k), dict):
@@ -303,9 +303,9 @@ class BaseHandler(object):
             task['taskid'] = self.get_taskid(task)
 
         if kwargs:
-            raise TypeError('crawl() got unexpected keyword argument: %s' % kwargs.keys())
+            raise TypeError('crawl() got unexpected keyword argument: {0!s}'.format(kwargs.keys()))
 
-        cache_key = "%(project)s:%(taskid)s" % task
+        cache_key = "{project!s}:{taskid!s}".format(**task)
         if cache_key not in self._follows_keys:
             self._follows_keys.add(cache_key)
             self._follows.append(task)

--- a/pyspider/libs/bench.py
+++ b/pyspider/libs/bench.py
@@ -61,7 +61,7 @@ def bench_test_taskdb(taskdb):
         logger.info("taskdb insert %d", n)
         start_time = time.time()
         for i in range(n):
-            task['url'] = 'http://bench.pyspider.org/?l=%d' % (i + start)
+            task['url'] = 'http://bench.pyspider.org/?l={0:d}'.format((i + start))
             task['taskid'] = md5string(task['url'])
             task['track'] = {}
             taskdb.insert(task['project'], task['taskid'], task)
@@ -71,10 +71,10 @@ def bench_test_taskdb(taskdb):
                     cost_time, n * 1.0 / cost_time, cost_time / n * 1000)
 
     def test_update(n, start=0):
-        logger.info("taskdb update %d" % n)
+        logger.info("taskdb update {0:d}".format(n))
         start_time = time.time()
         for i in range(n):
-            task['url'] = 'http://bench.pyspider.org/?l=%d' % (i + start)
+            task['url'] = 'http://bench.pyspider.org/?l={0:d}'.format((i + start))
             task['taskid'] = md5string(task['url'])
             task['track'] = track
             taskdb.update(task['project'], task['taskid'], task)
@@ -95,14 +95,14 @@ def bench_test_taskdb(taskdb):
     ]
 
     def test_get(n, start=0, random=True, fields=request_task_fields):
-        logger.info("taskdb get %d %s" % (n, "randomly" if random else ""))
+        logger.info("taskdb get {0:d} {1!s}".format(n, "randomly" if random else ""))
         range_n = list(range(n))
         if random:
             from random import shuffle
             shuffle(range_n)
         start_time = time.time()
         for i in range_n:
-            task['url'] = 'http://bench.pyspider.org/?l=%d' % (i + start)
+            task['url'] = 'http://bench.pyspider.org/?l={0:d}'.format((i + start))
             task['taskid'] = md5string(task['url'])
             task['track'] = track
             taskdb.get_task(task['project'], task['taskid'], fields=fields)
@@ -144,7 +144,7 @@ def bench_test_message_queue(queue):
         logger.info("message queue put %d", n)
         start_time = time.time()
         for i in range(n):
-            task['url'] = 'http://bench.pyspider.org/?l=%d' % i
+            task['url'] = 'http://bench.pyspider.org/?l={0:d}'.format(i)
             task['taskid'] = md5string(task['url'])
             queue.put(task, block=True, timeout=1)
         end_time = time.time()
@@ -194,7 +194,7 @@ class BenchMixin(object):
             output = ''
             if prefix:
                 output += " " * prefix
-            output += ("%s %s pages (at %d pages/min)" % (
+            output += ("{0!s} {1!s} pages (at {2:d} pages/min)".format(
                 name, self.done_cnt, rps * 60.0)).rjust(rjust)
             logger.info(output)
             self.last_cnt = self.done_cnt

--- a/pyspider/libs/counter.py
+++ b/pyspider/libs/counter.py
@@ -421,7 +421,7 @@ class CounterManager(DictMixin):
             with open(filename, 'wb') as fp:
                 cPickle.dump(self.counters, fp)
         except:
-            logging.error("can't dump counter to file: %s" % filename)
+            logging.error("can't dump counter to file: {0!s}".format(filename))
             return False
         return True
 
@@ -431,6 +431,6 @@ class CounterManager(DictMixin):
             with open(filename) as fp:
                 self.counters = cPickle.load(fp)
         except:
-            logging.debug("can't load counter from file: %s" % filename)
+            logging.debug("can't load counter from file: {0!s}".format(filename))
             return False
         return True

--- a/pyspider/libs/pprint.py
+++ b/pyspider/libs/pprint.py
@@ -168,9 +168,9 @@ class PrettyPrinter:
                     for key, ent in items[1:]:
                         rep = self._repr(key, context, level)
                         if sepLines:
-                            write(',\n%s%s: ' % (' ' * indent, rep))
+                            write(',\n{0!s}{1!s}: '.format(' ' * indent, rep))
                         else:
-                            write(', %s: ' % rep)
+                            write(', {0!s}: '.format(rep))
                         self._format(ent, stream, indent + _len(rep) + 2,
                                      allowance + 1, context, level)
                 indent = indent - self._indent_per_level
@@ -267,7 +267,7 @@ def _safe_repr(object, context, maxlevels, level):
             string = string.replace("'", "\\'")
         try:
             string.decode('utf8').encode('gbk', 'replace')
-            return ("%s%s%s" % (closure, string, closure)), True, False
+            return ("{0!s}{1!s}{2!s}".format(closure, string, closure)), True, False
         except:
             pass
         qget = quotes.get
@@ -278,7 +278,7 @@ def _safe_repr(object, context, maxlevels, level):
                 write(char)
             else:
                 write(qget(char, repr(char)[1:-1]))
-        return ("%s%s%s" % (closure, sio.getvalue(), closure)), True, False
+        return ("{0!s}{1!s}{2!s}".format(closure, sio.getvalue(), closure)), True, False
 
     if typ is six.text_type:
         string = object.encode("utf8", 'replace')
@@ -291,7 +291,7 @@ def _safe_repr(object, context, maxlevels, level):
             closure = "'"
             quotes = {"'": "\\'"}
             string = string.replace("'", "\\'")
-        return ("u%s%s%s" % (closure, string, closure)), True, False
+        return ("u{0!s}{1!s}{2!s}".format(closure, string, closure)), True, False
 
     r = getattr(typ, "__repr__", None)
     if issubclass(typ, dict) and r is dict.__repr__:
@@ -312,12 +312,12 @@ def _safe_repr(object, context, maxlevels, level):
         for k, v in _sorted(object.items()):
             krepr, kreadable, krecur = saferepr(k, context, maxlevels, level)
             vrepr, vreadable, vrecur = saferepr(v, context, maxlevels, level)
-            append("%s: %s" % (krepr, vrepr))
+            append("{0!s}: {1!s}".format(krepr, vrepr))
             readable = readable and kreadable and vreadable
             if krecur or vrecur:
                 recursive = True
         del context[objid]
-        return "{%s}" % _commajoin(components), readable, recursive
+        return "{{{0!s}}}".format(_commajoin(components)), readable, recursive
 
     if (issubclass(typ, list) and r is list.__repr__) or \
             (issubclass(typ, tuple) and r is tuple.__repr__):
@@ -357,8 +357,7 @@ def _safe_repr(object, context, maxlevels, level):
 
 
 def _recursion(object):
-    return ("<Recursion on %s with id=%s>"
-            % (_type(object).__name__, _id(object)))
+    return ("<Recursion on {0!s} with id={1!s}>".format(_type(object).__name__, _id(object)))
 
 
 def _perfcheck(object=None):

--- a/pyspider/libs/response.py
+++ b/pyspider/libs/response.py
@@ -36,7 +36,7 @@ class Response(object):
         self.time = 0
 
     def __repr__(self):
-        return u'<Response [%d]>' % self.status_code
+        return u'<Response [{0:d}]>'.format(self.status_code)
 
     def __bool__(self):
         """Returns true if `status_code` is 200 and no error"""
@@ -178,11 +178,11 @@ class Response(object):
         elif self.error:
             http_error = HTTPError(self.error)
         elif (self.status_code >= 300) and (self.status_code < 400) and not allow_redirects:
-            http_error = HTTPError('%s Redirection' % (self.status_code))
+            http_error = HTTPError('{0!s} Redirection'.format((self.status_code)))
         elif (self.status_code >= 400) and (self.status_code < 500):
-            http_error = HTTPError('%s Client Error' % (self.status_code))
+            http_error = HTTPError('{0!s} Client Error'.format((self.status_code)))
         elif (self.status_code >= 500) and (self.status_code < 600):
-            http_error = HTTPError('%s Server Error' % (self.status_code))
+            http_error = HTTPError('{0!s} Server Error'.format((self.status_code)))
         else:
             return
 

--- a/pyspider/libs/url.py
+++ b/pyspider/libs/url.py
@@ -52,7 +52,7 @@ def _build_url(url, _params):
     enc_params = _encode_params(_params)
     if enc_params:
         if query:
-            query = '%s&%s' % (query, enc_params)
+            query = '{0!s}&{1!s}'.format(query, enc_params)
         else:
             query = enc_params
     url = (urlunparse([scheme, netloc, path, params, query, fragment]))
@@ -64,9 +64,9 @@ def quote_chinese(url, encodeing="utf-8"):
     if isinstance(url, six.text_type):
         return quote_chinese(url.encode(encodeing))
     if six.PY3:
-        res = [six.int2byte(b).decode('latin-1') if b < 128 else '%%%02X' % b for b in url]
+        res = [six.int2byte(b).decode('latin-1') if b < 128 else '%{0:02X}'.format(b) for b in url]
     else:
-        res = [b if ord(b) < 128 else '%%%02X' % ord(b) for b in url]
+        res = [b if ord(b) < 128 else '%{0:02X}'.format(ord(b)) for b in url]
     return "".join(res)
 
 
@@ -93,7 +93,7 @@ def curl_to_arguments(curl):
         else:
             # option
             if current_opt is None:
-                raise TypeError('Unknow curl argument: %s' % part)
+                raise TypeError('Unknow curl argument: {0!s}'.format(part))
             elif current_opt in ('-H', '--header'):
                 key_value = part.split(':', 1)
                 if len(key_value) == 2:
@@ -108,13 +108,13 @@ def curl_to_arguments(curl):
             elif current_opt in ('-X', '--request'):
                 kwargs['method'] = part
             else:
-                raise TypeError('Unknow curl option: %s' % current_opt)
+                raise TypeError('Unknow curl option: {0!s}'.format(current_opt))
             current_opt = None
 
     if not urls:
         raise TypeError('curl: no URL specified!')
     if current_opt:
-        raise TypeError('Unknow curl option: %s' % current_opt)
+        raise TypeError('Unknow curl option: {0!s}'.format(current_opt))
 
     kwargs['urls'] = urls
     if headers:

--- a/pyspider/libs/utils.py
+++ b/pyspider/libs/utils.py
@@ -132,7 +132,7 @@ def format_date(date, gmt_offset=0, relative=True, shorter=False, full_format=Fa
         format = "%(month_name)s %(day)s, %(year)s" if shorter else \
             "%(month_name)s %(day)s, %(year)s at %(time)s"
 
-    str_time = "%d:%02d" % (local_date.hour, local_date.minute)
+    str_time = "{0:d}:{1:02d}".format(local_date.hour, local_date.minute)
 
     return format % {
         "month_name": local_date.strftime('%b'),

--- a/pyspider/message_queue/rabbitmq.py
+++ b/pyspider/message_queue/rabbitmq.py
@@ -225,7 +225,7 @@ class AmqpQueue(PikaQueue):
         """Reconnect to rabbitmq server"""
         parsed = urlparse.urlparse(self.amqp_url)
         port = parsed.port or 5672
-        self.connection = amqp.Connection(host="%s:%s" % (parsed.hostname, port),
+        self.connection = amqp.Connection(host="{0!s}:{1!s}".format(parsed.hostname, port),
                                           userid=parsed.username or 'guest',
                                           password=parsed.password or 'guest',
                                           virtual_host=unquote(

--- a/pyspider/processor/processor.py
+++ b/pyspider/processor/processor.py
@@ -193,7 +193,7 @@ class Processor(object):
             logger_func = logger.error
         else:
             logger_func = logger.info
-        logger_func('process %s:%s %s -> [%d] len:%d -> result:%.10r fol:%d msg:%d err:%r' % (
+        logger_func('process {0!s}:{1!s} {2!s} -> [{3:d}] len:{4:d} -> result:{5:.10!r} fol:{6:d} msg:{7:d} err:{8!r}'.format(
             task['project'], task['taskid'],
             task.get('url'), response.status_code, len(response.content),
             ret.result, len(ret.follows), len(ret.messages), ret.exception))

--- a/pyspider/processor/project_module.py
+++ b/pyspider/processor/project_module.py
@@ -199,7 +199,7 @@ class ProjectLoader(object):
             self.mod = mod = imp.new_module(fullname)
         else:
             mod = self.mod
-        mod.__file__ = '<%s>' % self.name
+        mod.__file__ = '<{0!s}>'.format(self.name)
         mod.__loader__ = self
         mod.__project__ = self.project
         mod.__package__ = ''
@@ -212,7 +212,7 @@ class ProjectLoader(object):
         return False
 
     def get_code(self, fullname):
-        return compile(self.get_source(fullname), '<%s>' % self.name, 'exec')
+        return compile(self.get_source(fullname), '<{0!s}>'.format(self.name), 'exec')
 
     def get_source(self, fullname):
         script = self.project['script']

--- a/pyspider/result/result_worker.py
+++ b/pyspider/result/result_worker.py
@@ -29,7 +29,7 @@ class ResultWorker(object):
         if not result:
             return
         if 'taskid' in task and 'project' in task and 'url' in task:
-            logger.info('result %s:%s %s -> %.30r' % (
+            logger.info('result {0!s}:{1!s} {2!s} -> {3:.30!r}'.format(
                 task['project'], task['taskid'], task['url'], result))
             return self.resultdb.save(
                 project=task['project'],
@@ -38,7 +38,7 @@ class ResultWorker(object):
                 result=result
             )
         else:
-            logger.warning('result UNKNOW -> %.30r' % result)
+            logger.warning('result UNKNOW -> {0:.30!r}'.format(result))
             return
 
     def quit(self):
@@ -73,7 +73,7 @@ class OneResultWorker(ResultWorker):
         if not result:
             return
         if 'taskid' in task and 'project' in task and 'url' in task:
-            logger.info('result %s:%s %s -> %.30r' % (
+            logger.info('result {0!s}:{1!s} {2!s} -> {3:.30!r}'.format(
                 task['project'], task['taskid'], task['url'], result))
             print(json.dumps({
                 'taskid': task['taskid'],
@@ -83,5 +83,5 @@ class OneResultWorker(ResultWorker):
                 'updatetime': time.time()
             }))
         else:
-            logger.warning('result UNKNOW -> %.30r' % result)
+            logger.warning('result UNKNOW -> {0:.30!r}'.format(result))
             return

--- a/pyspider/scheduler/scheduler.py
+++ b/pyspider/scheduler/scheduler.py
@@ -416,7 +416,7 @@ class Scheduler(object):
                    "retry:%(retry)d,failed:%(failed)d" % total_cnt)
         for _, project in itertools.chain(top_3_actives, top_2_fails):
             subcounter = self._cnt['5m'][project].to_dict(get_value='sum')
-            log_str += " %s:%d,%d,%d,%d" % (project,
+            log_str += " {0!s}:{1:d},{2:d},{3:d},{4:d}".format(project,
                                             subcounter.get('pending', 0),
                                             subcounter.get('success', 0),
                                             subcounter.get('retry', 0),
@@ -718,7 +718,7 @@ class Scheduler(object):
         if 'schedule' not in task:
             old_task = self.taskdb.get_task(task['project'], task['taskid'], fields=['schedule'])
             if old_task is None:
-                logging.error('unknown status pack: %s' % task)
+                logging.error('unknown status pack: {0!s}'.format(task))
                 return
             task['schedule'] = old_task.get('schedule', {})
 
@@ -747,7 +747,7 @@ class Scheduler(object):
             self._cnt['1h'].event((project, 'failed'), +1)
             self._cnt['1d'].event((project, 'failed'), +1)
             self._cnt['all'].event((project, 'failed'), +1).event((project, 'pending'), -1)
-            logger.info('task failed %(project)s:%(taskid)s %(url)s' % task)
+            logger.info('task failed {project!s}:{taskid!s} {url!s}'.format(**task))
             return task
         else:
             task['schedule']['retried'] = retried + 1
@@ -761,7 +761,7 @@ class Scheduler(object):
             self._cnt['1h'].event((project, 'retry'), +1)
             self._cnt['1d'].event((project, 'retry'), +1)
             # self._cnt['all'].event((project, 'retry'), +1)
-            logger.info('task retry %d/%d %%(project)s:%%(taskid)s %%(url)s' % (
+            logger.info('task retry {0:d}/{1:d} %(project)s:%(taskid)s %(url)s'.format(
                 retried, retries), task)
             return task
 
@@ -820,11 +820,10 @@ class OneScheduler(Scheduler):
                 if len(self.projects) == 1:
                     project = list(self.projects.keys())[0]
                 else:
-                    raise LookupError('You need specify the project: %r'
-                                      % list(self.projects.keys()))
+                    raise LookupError('You need specify the project: {0!r}'.format(list(self.projects.keys())))
             project_data = self.processor.project_manager.get(project)
             if not project_data:
-                raise LookupError('no such project: %s' % project)
+                raise LookupError('no such project: {0!s}'.format(project))
 
             # get task package
             instance = project_data['instance']

--- a/pyspider/webui/index.py
+++ b/pyspider/webui/index.py
@@ -30,7 +30,7 @@ def get_queues():
         try:
             return queue.qsize()
         except Exception as e:
-            return "%r" % e
+            return "{0!r}".format(e)
 
     result = {}
     queues = app.config.get('queues', {})
@@ -54,7 +54,7 @@ def project_update():
         return app.login_response
 
     if name not in ('group', 'status', 'rate'):
-        return 'unknown field: %s' % name, 400
+        return 'unknown field: {0!s}'.format(name), 400
     if name == 'rate':
         value = value.split('/')
         if len(value) != 2:

--- a/pyspider/webui/task.py
+++ b/pyspider/webui/task.py
@@ -46,7 +46,7 @@ def tasks():
     tasks = {}
     result = []
     for updatetime, task in sorted(updatetime_tasks , key=lambda x: x[0]):
-        key = '%(project)s:%(taskid)s' % task
+        key = '{project!s}:{taskid!s}'.format(**task)
         task['updatetime'] = updatetime
         if key in tasks and tasks[key].get('status', None) != taskdb.ACTIVE:
             result.append(tasks[key])

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -279,8 +279,8 @@ class ResultDBCase(object):
 
     def test_30_select(self):
         for i in range(5):
-            self.resultdb.save('test_project', 'test_taskid-%d' % i,
-                               'test_url', 'result-%d' % i)
+            self.resultdb.save('test_project', 'test_taskid-{0:d}'.format(i),
+                               'test_url', 'result-{0:d}'.format(i))
         ret = list(self.resultdb.select('test_project'))
         self.assertEqual(len(ret), 6)
 
@@ -610,8 +610,8 @@ class TestESResultDB(ResultDBCase, unittest.TestCase):
 
     def test_30_select(self):
         for i in range(5):
-            self.resultdb.save('test_project', 'test_taskid-%d' % i,
-                               'test_url', 'result-%d' % i)
+            self.resultdb.save('test_project', 'test_taskid-{0:d}'.format(i),
+                               'test_url', 'result-{0:d}'.format(i))
         self.resultdb.refresh()
 
         ret = list(self.resultdb.select('test_project'))

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -62,7 +62,7 @@ class TestFetcher(unittest.TestCase):
         self.outqueue = Queue(10)
         self.fetcher = Fetcher(self.inqueue, self.outqueue)
         self.fetcher.phantomjs_proxy = '127.0.0.1:25555'
-        self.rpc = xmlrpc_client.ServerProxy('http://localhost:%d' % 24444)
+        self.rpc = xmlrpc_client.ServerProxy('http://localhost:{0:d}'.format(24444))
         self.xmlrpc_thread = utils.run_in_thread(self.fetcher.xmlrpc_run, port=24444)
         self.thread = utils.run_in_thread(self.fetcher.run)
         self.proxy_thread = subprocess.Popen(['pyproxy', '--username=binux',

--- a/tests/test_fetcher_processor.py
+++ b/tests/test_fetcher_processor.py
@@ -53,7 +53,7 @@ class TestFetcherProcessor(unittest.TestCase):
             url = dataurl.encode(utils.text(kwargs.get('callback')))
 
         project_data = self.processor.project_manager.get(self.project_name)
-        assert project_data, "can't find project: %s" % self.project_name
+        assert project_data, "can't find project: {0!s}".format(self.project_name)
         instance = project_data['instance']
         instance._reset()
         task = instance.crawl(url, **kwargs)
@@ -460,12 +460,12 @@ class TestFetcherProcessor(unittest.TestCase):
     def test_zzz_curl_bad_option(self):
         with self.assertRaisesRegexp(TypeError, 'Unknow curl option'):
             status, newtasks, result = self.crawl(
-                '''curl '%s/put' -X PUT -H 'Origin: chrome-extension://hgmloofddffdnphfgcellkdfbfbjeloo' -v''' % self.httpbin,
+                '''curl '{0!s}/put' -X PUT -H 'Origin: chrome-extension://hgmloofddffdnphfgcellkdfbfbjeloo' -v'''.format(self.httpbin),
                 callback=self.json)
 
         with self.assertRaisesRegexp(TypeError, 'Unknow curl option'):
             status, newtasks, result = self.crawl(
-                '''curl '%s/put' -X PUT -v -H 'Origin: chrome-extension://hgmloofddffdnphfgcellkdfbfbjeloo' ''' % self.httpbin,
+                '''curl '{0!s}/put' -X PUT -v -H 'Origin: chrome-extension://hgmloofddffdnphfgcellkdfbfbjeloo' '''.format(self.httpbin),
                 callback=self.json)
 
 

--- a/tests/test_message_queue.py
+++ b/tests/test_message_queue.py
@@ -41,9 +41,9 @@ class TestMessageQueue(object):
         self.assertEqual(self.q1.qsize(), 0)
         self.assertEqual(self.q2.qsize(), 0)
         for i in range(2):
-            self.q1.put_nowait('TEST_DATA%d' % i)
+            self.q1.put_nowait('TEST_DATA{0:d}'.format(i))
         for i in range(3):
-            self.q2.put('TEST_DATA%d' % i)
+            self.q2.put('TEST_DATA{0:d}'.format(i))
         with self.assertRaises(Queue.Full):
             self.q1.put('TEST_DATA6', timeout=0.01)
         with self.assertRaises(Queue.Full):
@@ -52,7 +52,7 @@ class TestMessageQueue(object):
     def test_40_multiple_threading_error(self):
         def put(q):
             for i in range(100):
-                q.put("DATA_%d" % i)
+                q.put("DATA_{0:d}".format(i))
 
         def get(q):
             for i in range(100):

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -279,18 +279,18 @@ class TestRun(unittest.TestCase):
             text = wait_text()
             self.assertIn('task done data_sample_handler:on_start', text)
 
-            os.write(fd, utils.utf8('crawl("%s/pyspider/test.html")\n' % self.httpbin))
+            os.write(fd, utils.utf8('crawl("{0!s}/pyspider/test.html")\n'.format(self.httpbin)))
             text = wait_text()
             self.assertIn('/robots.txt', text)
 
-            os.write(fd, utils.utf8('crawl("%s/links/10/0")\n' % self.httpbin))
+            os.write(fd, utils.utf8('crawl("{0!s}/links/10/0")\n'.format(self.httpbin)))
             text = wait_text()
             if '"title": "Links"' not in text:
-                os.write(fd, utils.utf8('crawl("%s/links/10/1")\n' % self.httpbin))
+                os.write(fd, utils.utf8('crawl("{0!s}/links/10/1")\n'.format(self.httpbin)))
                 text = wait_text()
                 self.assertIn('"title": "Links"', text)
 
-            os.write(fd, utils.utf8('crawl("%s/404")\n' % self.httpbin))
+            os.write(fd, utils.utf8('crawl("{0!s}/404")\n'.format(self.httpbin)))
             text = wait_text()
             self.assertIn('task retry', text)
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -129,7 +129,7 @@ class TestScheduler(unittest.TestCase):
         self.newtask_queue = Queue(10)
         self.status_queue = Queue(10)
         self.scheduler2fetcher = Queue(10)
-        self.rpc = xmlrpc_client.ServerProxy('http://localhost:%d' % self.scheduler_xmlrpc_port)
+        self.rpc = xmlrpc_client.ServerProxy('http://localhost:{0:d}'.format(self.scheduler_xmlrpc_port))
 
         def run_scheduler():
             scheduler = Scheduler(taskdb=get_taskdb(), projectdb=get_projectdb(),
@@ -632,7 +632,7 @@ class TestScheduler(unittest.TestCase):
         pre_size = self.rpc.size()
         for i in range(20):
             self.newtask_queue.put({
-                'taskid': 'taskid%d' % i,
+                'taskid': 'taskid{0:d}'.format(i),
                 'project': 'test_inqueue_project',
                 'url': 'url',
                 'schedule': {


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:pyspider?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:pyspider?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
